### PR TITLE
dbt level up repo is buggy, i'm fixing it 

### DIFF
--- a/models/staging/jaffle_shop/_sources_jaffle_shop.yml
+++ b/models/staging/jaffle_shop/_sources_jaffle_shop.yml
@@ -1,10 +1,14 @@
 sources:
+  - name: jaffle_shop_new
+    database: raw
+    schema: jaffle_shop_new
+    tables:
+      - name: products
   - name: jaffle_shop
     database: raw
     schema: jaffle_shop
     tables:
       - name: customers
-      - name: products
       - name: orders
         freshness: # default freshness
           warn_after: {count: 15, period: day}

--- a/models/staging/jaffle_shop/stg_jaffle_shop__products.sql
+++ b/models/staging/jaffle_shop/stg_jaffle_shop__products.sql
@@ -2,7 +2,7 @@ with
 
 source as (
 
-    select * from {{ source('jaffle_shop', 'products') }}
+    select * from {{ source('jaffle_shop_new', 'products') }}
 
 ),
 


### PR DESCRIPTION
**Problem**: When you log in to the level-up workshop through cloud.getdbt.com/workshop, you can't do a dbt build. It errors out as is. 

**Solution**: The products staging table is pointing at the wrong product table. The correct product table is on a different schema. 

Please watch this [Zoom clip](https://dbtlabs.zoom.us/clips/share/j7qSwu_CQzqr3RwVyYIjvg) for a walk through of my solution for this--I want to make sure I've got it right and am not missing anything. 